### PR TITLE
Faraday response raise error

### DIFF
--- a/lib/active_campaign/client.rb
+++ b/lib/active_campaign/client.rb
@@ -42,6 +42,7 @@ module ActiveCampaign
         ActiveCampaign::Faraday::Middleware.add_response_middleware(faraday, config[:response_middleware])
 
         faraday.adapter config[:adapter]
+        faraday.response :raise_error, include_request: true
 
         if (options = faraday.options)
           options.timeout      = config[:api_timeout]

--- a/lib/active_campaign/errors.rb
+++ b/lib/active_campaign/errors.rb
@@ -29,12 +29,12 @@ module ActiveCampaign
         super
       else
         <<~MESSAGE
-          STATUS: #{response.status}
-          URL: #{env.url}
-          REQUEST HEADERS: #{env.request_headers}
-          RESPONSE_HEADERS: #{env.response_headers}
-          REQUEST_BODY: #{env.request_body}\n\n"
-          RESPONSE_BODY: #{response.body}\n\n"
+          STATUS: #{response.response[:status]}
+          URL: #{response.response[:request][:url_path]}
+          REQUEST HEADERS: #{response.response[:request][:headers]}
+          RESPONSE_HEADERS: #{response.response[:headers]}
+          REQUEST_BODY: #{response.response[:request][:body]}\n\n"
+          RESPONSE_BODY: #{response.response[:body]}\n\n"
         MESSAGE
       end
     end


### PR DESCRIPTION
Enables Faraday raise_error middleware to ensure all the non-success responses fail loudly